### PR TITLE
Update template_config.yml

### DIFF
--- a/template_config.yml
+++ b/template_config.yml
@@ -62,7 +62,8 @@ servers:
     # MINIMUM: 0
     # MAXIMUM: 65535
     # REQUIRED
-    port: ''
+    # Omit single quotes for integer value
+    port: 
 
     # Transport protocol used to communicate with the server
     # OPTIONS: TCP, TCPSSL, UDP


### PR DESCRIPTION
Removed single quotes from port specification and added comment.
When specifying port with single quotes, the value will not be parsed as an integer and the config.yml file will fail to load.