### PR TITLE
Added Http Proxy support for Duo requests

### DIFF
--- a/duologsync/app.py
+++ b/duologsync/app.py
@@ -94,7 +94,8 @@ def create_tasks(server_to_writer):
     # Object with functions needed to utilize log API calls
     admin = create_admin(
         Config.get_account_ikey(), Config.get_account_skey(),
-        Config.get_account_hostname(), is_msp=Config.account_is_msp())
+        Config.get_account_hostname(), is_msp=Config.account_is_msp(),
+        proxy_server=Config.get_proxy_server(), proxy_port=Config.get_proxy_port())
 
     # This is where functionality would be added to check if an account is MSP
     # (Config.account_is_msp), and then retrieve child accounts (ignoring those

--- a/duologsync/config.py
+++ b/duologsync/config.py
@@ -36,8 +36,8 @@ class Config:
     API_TIMEOUT_DEFAULT = 120
     CHECKPOINTING_ENABLED_DEFAULT = False
     CHECKPOINTING_DIRECTORY_DEFAULT = DIRECTORY_DEFAULT
-    PROXY_SERVER_DEFAULT = None
-    PROXY_PORT_DEFAULT = None
+    PROXY_SERVER_DEFAULT = ''
+    PROXY_PORT_DEFAULT = 0
 
     # To understand these schema definitions better, compare side-by-side to
     # the template_config.yml file
@@ -101,12 +101,10 @@ class Config:
                 'schema': {
                     'proxy_server': {
                         'type': 'string',
-                        'nullable': True,
                         'default': PROXY_SERVER_DEFAULT
                     },
                     'proxy_port': {
                         'type': 'number',
-                        'nullable': True,
                         'default': PROXY_PORT_DEFAULT
 
                     }
@@ -236,20 +234,15 @@ class Config:
     def get_value(cls, keys):
         """
         Getter for a Config object's 'config' instance variable
-        DK: Moved from checking for None to checking for the presence of the key since the proxy settings are None by default
         """
 
         cls._check_config_is_set()
         curr_value = cls._config
         for key in keys:
-
-            if key not in curr_value:
-                raise ValueError(f"{key} is an invalid key for this Config")
-
             curr_value = curr_value.get(key)
 
-            # if curr_value is None:
-            #     raise ValueError(f"{key} is an invalid key for this Config")
+            if curr_value is None:
+                raise ValueError(f"{key} is an invalid key for this Config")
 
         return curr_value
 

--- a/duologsync/config.py
+++ b/duologsync/config.py
@@ -36,6 +36,8 @@ class Config:
     API_TIMEOUT_DEFAULT = 120
     CHECKPOINTING_ENABLED_DEFAULT = False
     CHECKPOINTING_DIRECTORY_DEFAULT = DIRECTORY_DEFAULT
+    PROXY_SERVER_DEFAULT = None
+    PROXY_PORT_DEFAULT = None
 
     # To understand these schema definitions better, compare side-by-side to
     # the template_config.yml file
@@ -91,6 +93,23 @@ class Config:
                         'type': 'string',
                         'empty': False,
                         'default': CHECKPOINTING_DIRECTORY_DEFAULT}
+                }
+            },
+            'proxy': {
+                'type': 'dict',
+                'default': {},
+                'schema': {
+                    'proxy_server': {
+                        'type': 'string',
+                        'nullable': True,
+                        'default': PROXY_SERVER_DEFAULT
+                    },
+                    'proxy_port': {
+                        'type': 'number',
+                        'nullable': True,
+                        'default': PROXY_PORT_DEFAULT
+
+                    }
                 }
             }
         }
@@ -217,15 +236,20 @@ class Config:
     def get_value(cls, keys):
         """
         Getter for a Config object's 'config' instance variable
+        DK: Moved from checking for None to checking for the presence of the key since the proxy settings are None by default
         """
 
         cls._check_config_is_set()
         curr_value = cls._config
         for key in keys:
+
+            if key not in curr_value:
+                raise ValueError(f"{key} is an invalid key for this Config")
+
             curr_value = curr_value.get(key)
 
-            if curr_value is None:
-                raise ValueError(f"{key} is an invalid key for this Config")
+            # if curr_value is None:
+            #     raise ValueError(f"{key} is an invalid key for this Config")
 
         return curr_value
 
@@ -294,6 +318,16 @@ class Config:
     def account_is_msp(cls):
         """@return whether the account in config is an MSP account"""
         return cls.get_value(['account', 'is_msp'])
+
+    @classmethod
+    def get_proxy_server(cls):
+        """@return the proxy_server in config"""
+        return cls.get_value(['dls_settings', 'proxy', 'proxy_server'])
+
+    @classmethod
+    def get_proxy_port(cls):
+        """@return the proxy_port in config"""
+        return cls.get_value(['dls_settings', 'proxy', 'proxy_port'])
 
     @classmethod
     def create_config(cls, config_filepath):

--- a/duologsync/producer/producer.py
+++ b/duologsync/producer/producer.py
@@ -58,10 +58,11 @@ class Producer():
                     Program.log(f"{self.log_type} producer: no new logs available",
                                 logging.INFO)
 
-            # Horribly messed up hostname was provided for duoclient host
+            # Incorrect api_hostname or proxy_server was provided
+            # duo_client throws the same error if either the api_hostname or proxy_server is incorrect
             except (gaierror, OSError) as error:
                 shutdown_reason = f"{self.log_type} producer: [{error}]"
-                Program.log('DuoLogSync: check that the duoclient host '
+                Program.log('DuoLogSync: check that the duoclient host and/or proxy_server '
                             'provided in the config file is correct')
 
             # duo_client throws a RuntimeError if the ikey or skey is invalid

--- a/duologsync/util.py
+++ b/duologsync/util.py
@@ -102,16 +102,17 @@ def get_log_offset(log_type, recover_log_offset, checkpoint_directory, child_acc
     return log_offset
 
 
-def create_admin(ikey, skey, host, is_msp=False):
+def create_admin(ikey, skey, host, is_msp=False, proxy_server=None, proxy_port=None):
     """
     Create an Admin object (from the duo_client library) with the given values.
     The Admin object has many functions for using Duo APIs and retrieving logs.
 
     @param ikey Duo Client ID (Integration Key)
-    @param skey Duo Client Secret for proving identity / access (Secrey Key)
+    @param skey Duo Client Secret for proving identity / access (Secret Key)
     @param host URI where data / logs will be fetched from
     @param is_msp Indicates where we are using MSP account for logs retrieval
-
+    @param proxy_server Host/IP of Http Proxy if in use or None
+    @param proxy_port Port of Http Proxy if in use or None
     @return a newly created Admin object
     """
 
@@ -133,6 +134,11 @@ def create_admin(ikey, skey, host, is_msp=False):
         )
         Program.log(f"duo_client Admin initialized for ikey: {ikey}, host: {host}",
                     logging.INFO)
+
+    if proxy_server and proxy_port:
+        admin.set_proxy(host=proxy_server, port=proxy_port)
+        Program.log(f"duo_client Proxy configured: {proxy_server}:{proxy_port}", logging.INFO)
+
 
     return admin
 

--- a/template_config.yml
+++ b/template_config.yml
@@ -49,6 +49,15 @@ version: '1.0.0'
     # Directory where checkpoint files should be stored.
     #directory: '/tmp'
 
+  # Setting related to Http Proxy to proxy Duo requests
+  #proxy:
+
+    # Host/IP for Http Proxy
+    #proxy_server: 'example.proxy.com'
+
+    # Port for Http Proxy
+    #proxy_port: 8080
+
 # List of servers and how DLS will communicate with them
 servers:
   


### PR DESCRIPTION
Support for configuring a http proxy already existed in the Python duo_client, this update simply incorporates it into Duo Log Sync.