### PR TITLE
Support for duologsync.log Rotation & Max File Size

### DIFF
--- a/duologsync/program.py
+++ b/duologsync/program.py
@@ -3,6 +3,8 @@ Definition of the Program class
 """
 
 import logging
+from logging.handlers import RotatingFileHandler
+
 
 class ProgramShutdownError(Exception):
     """
@@ -75,6 +77,11 @@ class Program:
                 # Date format to use with logs
                 datefmt='%Y-%m-%d %H:%M:%S'
             )
+            
+            #  Log rotation, allows for 3 rotations, each at 25MB.
+            logger = logging.getLogger()
+            handler = RotatingFileHandler(log_filepath, maxBytes=26214400, backupCount=3)
+            logger.addHandler(handler)
 
         except FileNotFoundError as file_not_found_error:
             cls.log(f"DuoLogSync: Could not follow the path {log_filepath}. "


### PR DESCRIPTION
RotatingFileHandler is necessary to prevent the duologsync.log file from increasing in size indefinitely until the disk fills.

This allows for 3 rotations of the log file (4 total), each capping at 25MB.

We tested this and it appears to be working, but I recommend additional testing or adjusting of the added code as desired.