### PR TITLE
Update README.md to add step for installation of requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ MSP customers gathering logs from linked accounts should create an **Accounts AP
 - Make sure you are running Python 3+ with `python --version`.
 - Clone this GitHub repository and navigate to the `duo_log_sync` folder.
 - Ensure you have "setuptools" by running `pip3 install setuptools`.
+- Install required packages by running `pip/pip3 install -r requirements.txt`.
 - Install `duologsync` by running `python/python3 setup.py install`. 
 - Refer to the `Configuration` section below. You will need to create a `config.yml` file and fill out credentials for the adminapi in the duoclient section as well as other parameters if necessary.
 - Run the application using `duologsync <complete/path/to/config.yml>`.


### PR DESCRIPTION
## Description
Add pip installation step for requirements.txt to the README instructions

## Motivation and Context
The explicit step to install the required python packages prior to execution of setup.py is needed to prevent potential installation errors that may occur when required packages call setuputils on their own.

## How Has This Been Tested?
Manual testing of installation steps performed in a virtual environment.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation
